### PR TITLE
Update middleware dependencies and apply type changes

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -31,7 +31,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/src/app/Http/Kernel.php
+++ b/src/app/Http/Kernel.php
@@ -16,12 +16,11 @@ class Kernel extends HttpKernel
     protected $middleware = [
         // \App\Http\Middleware\TrustHosts::class,
         \App\Http\Middleware\TrustProxies::class,
-        \Fruitcake\Cors\HandleCors::class,
+        \Illuminate\Http\Middleware\HandleCors::class,
         \App\Http\Middleware\PreventRequestsDuringMaintenance::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
-        \Fruitcake\Cors\HandleCors::class,
     ];
 
     /**
@@ -41,7 +40,7 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
-            'throttle:api',
+            \Illuminate\Routing\Middleware\ThrottleRequests::class.':api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],
     ];

--- a/src/app/Http/Middleware/TrustProxies.php
+++ b/src/app/Http/Middleware/TrustProxies.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Middleware;
 
-use Fideloper\Proxy\TrustProxies as Middleware;
+use Illuminate\Http\Middleware\TrustProxies as Middleware;
 use Illuminate\Http\Request;
 
 class TrustProxies extends Middleware
@@ -10,7 +10,7 @@ class TrustProxies extends Middleware
     /**
      * The trusted proxies for this application.
      *
-     * @var array|string|null
+     * @var array<int, string>|string|null
      */
     protected $proxies;
 
@@ -19,5 +19,10 @@ class TrustProxies extends Middleware
      *
      * @var int
      */
-    protected $headers = Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO | Request::HEADER_X_FORWARDED_AWS_ELB;
+    protected $headers =
+        Request::HEADER_X_FORWARDED_FOR |
+        Request::HEADER_X_FORWARDED_HOST |
+        Request::HEADER_X_FORWARDED_PORT |
+        Request::HEADER_X_FORWARDED_PROTO |
+        Request::HEADER_X_FORWARDED_AWS_ELB;
 }

--- a/src/app/Logger/DatabaseHandler.php
+++ b/src/app/Logger/DatabaseHandler.php
@@ -7,7 +7,7 @@ use Monolog\Handler\AbstractProcessingHandler;
 
 class DatabaseHandler extends AbstractProcessingHandler
 {
-    protected function write(array $record): void
+    protected function write(\Monolog\LogRecord $record): void
     {
         LogMessage::create([
             'level' => $record['level'],

--- a/src/composer.json
+++ b/src/composer.json
@@ -12,24 +12,22 @@
         "arrilot/laravel-widgets": "^3.13",
         "darkaonline/l5-swagger": "^8.3",
         "doctrine/dbal": "^3.3",
-        "elasticsearch/elasticsearch": "^7.0",
-        "fideloper/proxy": "^4.4",
-        "fruitcake/laravel-cors": "^3.0",
         "guzzlehttp/guzzle": "^7.4.0",
-        "laravel/framework": "^9.0",
-        "laravel/tinker": "^2.7",
+        "laravel/framework": "^10.10",
+        "laravel/tinker": "^2.8",
         "league/flysystem-aws-s3-v3": "^3.0",
-        "monolog/monolog": "^2.5",
+        "laravel/sanctum": "^3.3",
+        "monolog/monolog": "^3.0",
         "predis/predis": "^1.1",
         "torann/geoip": "^3.0"
     },
     "require-dev": {
-        "spatie/laravel-ignition": "^1.0",
-        "fakerphp/faker": "^1.19.0",
+        "spatie/laravel-ignition": "^2.0",
+        "fakerphp/faker": "^1.9.1",
         "laravel/sail": "^1.0.1",
         "mockery/mockery": "^1.5.0",
-        "nunomaduro/collision": "^6.1",
-        "phpunit/phpunit": "^9.3.3"
+        "nunomaduro/collision": "^7.0",
+        "phpunit/phpunit": "^10.0"
     },
     "config": {
         "optimize-autoloader": true,


### PR DESCRIPTION
This commit updates the middleware dependencies, replacing the Fideloper and Fruitcake packages with their Illuminate counterparts. It adjusts the types in TrustProxies and DatabaseHandler files to enhance the type-safety. In the composer.json file, outdated packages have been removed and remaining ones have been updated to their latest stable versions.