### PR TITLE
Update support for YouTube and extend the copyright date

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ name: your-cast
 services:
   web:
     container_name: podcasts_web
-    image: your-cast/account:1.0.0
+    image: kuchura/your-cast-frontend:1.0.1-8df2a01
     ports:
       - "8001:80"
 

--- a/src/resources/views/layouts/app.blade.php
+++ b/src/resources/views/layouts/app.blade.php
@@ -7,7 +7,7 @@
     <meta name="description" content="@yield('description')">
     <meta name="keywords" content="@yield('keywords')">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="shorBtcut icon" type="image/x-icon" href="img/favicon.ico">
+    <link rel="shorBtcut icon" type="image/x-icon" href="{{ asset('/img/favicon.ico') }}">
     <!-- CSS here -->
     <link rel="stylesheet" href="{{ asset('/css/app.css') }}">
     <!-- csrf-token -->
@@ -18,7 +18,6 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-
         gtag('config', 'G-WSZSHH946B');
     </script>
 </head>
@@ -31,5 +30,3 @@
 <script src="{{ asset('/js/app.js') }}"></script>
 </body>
 </html>
-
-

--- a/src/resources/views/widgets/about.blade.php
+++ b/src/resources/views/widgets/about.blade.php
@@ -5,7 +5,7 @@
                 <div class="section-title text-center pl-40 pr-40 mb-45">
                     <h2>All you need</h2>
                     <p>
-                        Everything you need to create & share your podcast in any Podcast service (Apple Podcast, Google Podcast, Spotify).
+                        Everything you need to create & share your podcast in any Podcast service (Apple Podcast, YouTube, Spotify).
                     </p>
                 </div>
             </div>

--- a/src/resources/views/widgets/footer.blade.php
+++ b/src/resources/views/widgets/footer.blade.php
@@ -10,7 +10,7 @@
                         </div>
                         <div class="footer-text mb-20">
                             <p>
-                                Find and grow your show on every podcast listening app there is - including Apple Podcasts, Spotify, Google Podcasts, Amazon Music and others.
+                                Find and grow your show on every podcast listening app there is - including Apple Podcasts, Spotify, YouTube, Amazon Music and others.
                             </p>
                         </div>
                         <div class="footer-social">
@@ -76,7 +76,7 @@
             <div class="row">
                 <div class="col-12">
                     <div class="copyright-text">
-                        <p>&copy; 2021 - 2022 Your-Cast platform</p>
+                        <p>&copy; 2021 - 2024 Your-Cast platform</p>
                     </div>
                 </div>
             </div>

--- a/src/resources/views/widgets/slider.blade.php
+++ b/src/resources/views/widgets/slider.blade.php
@@ -14,7 +14,7 @@
                     <h2 data-animation="fadeInUp" data-delay=".4s">Home for your <span>Podcast</span></h2>
                     <p data-animation="fadeInUp" data-delay=".6s">
                         With Your-Cast platform you receive, strong application for create and update your podcast ecosystem.
-                        Import from another services, and work with Google Podcast, Apple Podcast, Spotify.
+                        Import from another services, and work with YouTube, Apple Podcast, Spotify.
                     </p>
 {{--                    <div class="slider-btn mt-30 mb-30">--}}
 {{--                        <a href="#" class="btn ss-btn" data-animation="fadeInUp" data-delay=".8s">Read More</a>--}}


### PR DESCRIPTION
This commit replaces "Google Podcast" with "YouTube" in the description for our podcast services, reflecting that we now support YouTube as a platform for our users. Moreover, the copyright date in footer has been extended to 2024. The image in the docker-compose file has also been updated to "kuchura/your-cast-frontend:1.0.1-8df2a01".