### PR TITLE
Add name to docker-compose configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,7 @@
 version: "3.9"
 
+name: your-cast
+
 services:
   web:
     container_name: podcasts_web


### PR DESCRIPTION
A 'name' field has been added to our docker-compose.yml. This can be used for referencing the compose project in commands instead of the default project name, providing easier command line interactions.