### PR TITLE
Remove unnecessary name field in docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,5 @@
 version: "3.9"
 
-name: your-cast
-
 services:
   web:
     container_name: podcasts_web


### PR DESCRIPTION
The unnecessary 'name' field was removed from the docker-compose.yml file. This change simplifies the configuration, ensuring there are no parameters that could lead to confusion in the future.