### PR TITLE
Remove unnecessary data-uk-scroll attributes

### DIFF
--- a/src/resources/views/widgets/footer.blade.php
+++ b/src/resources/views/widgets/footer.blade.php
@@ -20,13 +20,20 @@
 
         <div class="col-lg-2 col-md-6 col-sm-12 col-xs-12 center-col md-margin-bottom-50px sm-text-center">
             <p class="text-weight-500 text-extra-large text-gray-light no-margin">Pages</p>
-            <div
-                class="separator width-50 bottom-border border-1px border-color-gray-extra-dark margin-top-20px margin-bottom-20px sm-width-100"></div>
+            <div class="separator width-50 bottom-border border-1px border-color-gray-extra-dark margin-top-20px margin-bottom-20px sm-width-100"></div>
             <ul class="list-unstyled no-margin">
-                <li class="no-margin"><p><a class="text-gray-light" href="{{ route('home') }}">Home</a></p></li>
+                <li class="no-margin">
+                    <p>
+                        <a class="text-gray-light" href="{{ route('home') }}">Home</a>
+                    </p>
+                </li>
             </ul>
             <ul class="list-unstyled no-margin">
-                <li class="no-margin"><p><a class="text-gray-light" href="{{ route('contacts') }}">Contacts</a></p></li>
+                <li class="no-margin">
+                    <p>
+                        <a class="text-gray-light" href="{{ route('contacts') }}">Contacts</a>
+                    </p>
+                </li>
             </ul>
         </div>
 

--- a/src/resources/views/widgets/header.blade.php
+++ b/src/resources/views/widgets/header.blade.php
@@ -2,17 +2,17 @@
     <div class="navbar-dark" data-uk-sticky>
         <nav class="uk-navbar-container" data-uk-navbar="boundary-align: true; align: center;">
             <div class="uk-navbar-left padding-left-two-percent">
-                <a class="uk-navbar-item uk-logo" href="{{ route('home') }}" data-uk-scroll>
+                <a class="uk-navbar-item uk-logo" href="{{ route('home') }}">
                     <img src="/logo/your-cast-logo-white.png" alt=""/>
                 </a>
             </div>
             <div class="uk-navbar-right uk-light padding-right-two-percent">
                 <ul class="uk-navbar-nav text-weight-300">
                     <li>
-                        <a class="uk-visible@m" href="{{ route('home') }}" data-uk-scroll>Home</a>
+                        <a class="uk-visible@m" href="{{ route('home') }}">Home</a>
                     </li>
                     <li>
-                        <a class="uk-visible@m" href="{{ route('contacts') }}" data-uk-scroll>Contacts</a>
+                        <a class="uk-visible@m" href="{{ route('contacts') }}">Contacts</a>
                     </li>
                 </ul>
 {{--                <a class="btn btn-small btn-green sm-display-table sm-margin-left-right-auto" target="_blank" href="https://account.your-cast.com">--}}


### PR DESCRIPTION
Eliminated redundant data-uk-scroll attributes from header and footer views to simplify the codebase. This change cleans up the HTML and improves readability without affecting functionality.