### PR TITLE
Refactor `get` method to return a `Show` object

### DIFF
--- a/src/app/Repositories/ShowsRepository.php
+++ b/src/app/Repositories/ShowsRepository.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Str;
 
 class ShowsRepository implements Repository
 {
-    public function get(int $id): Collection
+    public function get(int $id): ?Show
     {
         return Show::with('episodes')->find($id);
     }


### PR DESCRIPTION
Modified the `get` method in `ShowsRepository` to return a `Show` object instead of a `Collection`. This ensures that the method returns either a `Show` object or `null`, aligning with typical repository patterns.